### PR TITLE
Use the EAP operator for deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ This repository has the complete coolstore monolith built as a Java EE 7 applica
 oc new-project coolstore
 ```
 
-## Deploy the RH-SSO anD AMQ Operators
+## Deploy the RH-SSO, AMQ and EAP Operators
 
 ```
 oc apply -f ./openshift/operators
 ```
 
-Wait for both operators to to be deployed (waiting until their ClusterServiceVersion's `PHASE` is set to `Suceeded`)
+Wait for the operators to to be deployed (waiting until their ClusterServiceVersion's `PHASE` is set to `Suceeded`)
 
 ```
 oc get csv -w
@@ -29,8 +29,9 @@ Once they are installed, it will display:
 
 ```
 NAME                           DISPLAY                           VERSION         REPLACES                       PHASE
-rhsso-operator.7.6.2-opr-001   Red Hat Single Sign-On Operator   7.6.2-opr-001   rhsso-operator.7.6.1-opr-005   Succeeded
+rhsso-operator.7.6.2-opr-001                       Red Hat Single Sign-On Operator                           7.6.2-opr-001                 rhsso-operator.7.6.1-opr-005        Succeeded
 amq-broker-operator.v7.10.2-opr-2-0.1676475747.p   Red Hat Integration - AMQ Broker for RHEL 8 (Multiarch)   7.10.2-opr-2+0.1676475747.p   amq-broker-operator.v7.10.2-opr-1   Succeeded
+eap-operator.v2.3.10                               JBoss EAP                                                 2.3.10                        eap-operator.v2.3.9                 Succeeded
 ```
 
 ## Deploy the RH-SSO instance, the AMQ Broker and the PostgreSQL
@@ -47,17 +48,30 @@ Run `oc get route keycloak ` (it may take a few attempts for route to be created
     value: https://keycloak-coolstore.apps.92393e11c4ffbef7e179.hypershift.aws-2.ci.openshift.org/auth
 ````
 
-## Deploy the application
-
-Create config map from cm.yaml
-
-```
-oc apply -f ./openshift/app/cm.yaml
-```
+## Build the application image
 
 From the developer UI, click on "+Add", then "Helm Chart", and select the "Eap74" Helm chart.
 
-Paste the contents of `openshift/app/helm.yml` as the config.
+Paste the contents of `openshift/helm.yml` as the config.
+
+Wait for the application image to be built
+
+```
+oc get build -w
+```
+
+The application image is built when the `eap74-2` build is `complete`:
+
+```
+NAME                      TYPE     FROM          STATUS    STARTED         DURATION
+eap74-2                   Docker   Dockerfile    Complete   About a minute ago   1m2s
+```
+
+## Deploy the application
+
+```
+oc apply -f ./openshift/app
+```
 
 ## Testing the application
 

--- a/openshift/app/eap.yml
+++ b/openshift/app/eap.yml
@@ -1,18 +1,9 @@
-build:
-  uri: https://github.com/deewhyweb/eap-coolstore-monolith.git
-  ref: ocp
-  s2i:
-    featurePacks:
-      - 'org.jboss.eap:eap-datasources-galleon-pack:7.4.0.GA-redhat-00003'
-    galleonLayers:
-      - cloud-server
-      - postgresql-datasource
-      - ejb
-      - web-clustering
-  env:
-    - name: POSTGRESQL_DRIVER_VERSION
-      value: 42.6.0
-deploy:
+apiVersion: wildfly.org/v1alpha1
+kind: WildFlyServer
+metadata:
+  name: eap74
+spec:
+  applicationImage: eap74:latest
   replicas: 1
   envFrom:
     - configMapRef:
@@ -43,4 +34,4 @@ deploy:
     # Make sure to update the KEYCLOAK_URL with the content of `oc get route keycloak`
     # Do not forget to prepend `https://` and append `/auth`
     - name: KEYCLOAK_URL
-      value: https://keycloak-coolstore.apps.66d651e5e828bba717d8.hypershift.aws-2.ci.openshift.org/auth
+      value: https://keycloak-coolstore.apps.65c7d3b08ce499ca2f7a.hypershift.aws-2.ci.openshift.org/auth

--- a/openshift/helm.yml
+++ b/openshift/helm.yml
@@ -1,0 +1,16 @@
+build:
+  uri: https://github.com/deewhyweb/eap-coolstore-monolith.git
+  ref: ocp
+  s2i:
+    featurePacks:
+      - 'org.jboss.eap:eap-datasources-galleon-pack:7.4.0.GA-redhat-00003'
+    galleonLayers:
+      - cloud-server
+      - postgresql-datasource
+      - ejb
+      - web-clustering
+  env:
+    - name: POSTGRESQL_DRIVER_VERSION
+      value: 42.6.0
+deploy:
+  enabled: false

--- a/openshift/operators/eap-operator.yml
+++ b/openshift/operators/eap-operator.yml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: eap
+  namespace: openshift-operators
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: eap 
+  source:  redhat-operators 
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
@deewhyweb If that interests you, these are the changes to use the EAP Operator to deploy the application (instead of using a raw Kubernetes `Deployment`)

The workflow is not that bad:
* you still use the Helm chart to build the application image
* you then deploy the application with the `ConfigMap` and a `WildFlyServer` resource.
  * the configuration of the application with env vars has been moved to the `WildFlyServer` spec verbatim.